### PR TITLE
Reintroduce Zenodo metadata for related identifiers

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -329,5 +329,13 @@
     "description": "This dataset is a CSV snapshot of The Perovskite Database available at www.perovskitedatabase.com.",
     "license": "CC-BY-4.0",
     "title": "The Perovskite Database (Archive)",
+    "related_identifiers": [
+        {
+            "scheme": "doi",
+            "identifier": "10.1038/s41560-021-00941-3",
+            "resource_type": "publication-article",
+            "relation": "isDescribedBy"
+        }
+    ],
     "upload_type": "dataset"
 }


### PR DESCRIPTION
Related to #2. We still need to wait for the Zenodo bug fix (and the assumption that the next release would not be for a while was wrong).